### PR TITLE
Fix for issue #78

### DIFF
--- a/rootfs/common/usr/share/container/tools
+++ b/rootfs/common/usr/share/container/tools
@@ -5,5 +5,5 @@ function GetWorkspaceDirectory() {
 }
 
 function GetWorkspaceName {
-  echo "$(find /workspaces -mindepth 1 -maxdepth 1 -type d)/"
+  echo "$(find /workspaces -mindepth 2 -maxdepth 2 -type d -name custom_components -exec dirname {} \;)/"
 }


### PR DESCRIPTION
Changed find arguments to only match custom_components under a subfolder of /workspaces to ignore non component projects