### PR TITLE
Fix GetWorkspaceName for GitHub Codespaces.

### DIFF
--- a/rootfs/common/usr/share/container/tools
+++ b/rootfs/common/usr/share/container/tools
@@ -5,9 +5,8 @@ function GetWorkspaceDirectory() {
 }
 
 function GetWorkspaceName {
-    if [[ -n "$CODESPACE_VSCODE_FOLDER" ]] && [[ "$CONTAINER_TYPE" == "integration"* ]]
-    then
-        echo "${CODESPACE_VSCODE_FOLDER}/"
+    if [[ -n "$WORKSPACE_DIRECTORY" ]]; then
+        echo "${WORKSPACE_DIRECTORY}/"
     else
         echo "$(find /workspaces -mindepth 1 -maxdepth 1 -type d)/"
     fi

--- a/rootfs/common/usr/share/container/tools
+++ b/rootfs/common/usr/share/container/tools
@@ -5,5 +5,5 @@ function GetWorkspaceDirectory() {
 }
 
 function GetWorkspaceName {
-  echo "$(find /workspaces -mindepth 1 -maxdepth 1 -type d)/"
+    echo "$(find /workspaces -mindepth 1 -maxdepth 1 -type d -not -path '*/\.*')/"
 }

--- a/rootfs/common/usr/share/container/tools
+++ b/rootfs/common/usr/share/container/tools
@@ -7,7 +7,7 @@ function GetWorkspaceDirectory() {
 function GetWorkspaceName {
     if [[ -n "$CODESPACE_VSCODE_FOLDER" ]] && [[ "$CONTAINER_TYPE" == "integration"* ]]
     then
-        echo "$CODESPACE_VSCODE_FOLDER"
+        echo "${CODESPACE_VSCODE_FOLDER}/"
     else
         echo "$(find /workspaces -mindepth 1 -maxdepth 1 -type d)/"
     fi

--- a/rootfs/common/usr/share/container/tools
+++ b/rootfs/common/usr/share/container/tools
@@ -5,5 +5,10 @@ function GetWorkspaceDirectory() {
 }
 
 function GetWorkspaceName {
-    echo "$(find /workspaces -mindepth 1 -maxdepth 1 -type d -not -path '*/\.*')/"
+    if [[ -n "$CODESPACE_VSCODE_FOLDER" ]] && [[ "$CONTAINER_TYPE" == "integration"* ]]
+    then
+        echo "$CODESPACE_VSCODE_FOLDER"
+    else
+        echo "$(find /workspaces -mindepth 1 -maxdepth 1 -type d)/"
+    fi
 }


### PR DESCRIPTION
GitHub Codespaces sticks a few "dot folders" in the /workspaces root. These folders cause GetWorkspaceName to return multiple results, breaking downstream functions. This change adds a filter to the find command to exclude folders beginning with a period.

Alternatively, this could be modified to check for and use the CODESPACE_VSCODE_FOLDER environment variable if available.