### PR TITLE
Update pip command to use https instead of the unencrypted git protocol

### DIFF
--- a/container/helpers/common/homeassistant/start.sh
+++ b/container/helpers/common/homeassistant/start.sh
@@ -34,7 +34,7 @@ fi
 echo "Start Home Assistant"
 if ! [ -x "$(command -v hass)" ]; then
   echo "Home Assistant is not installed, running installation."
-  python3 -m pip --disable-pip-version-check install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev
+  python3 -m pip --disable-pip-version-check install --upgrade git+https://github.com/home-assistant/home-assistant.git@dev
 fi
 hass --script ensure_config -c /config
 hass -c /config


### PR DESCRIPTION
The unencrypted git protocol is being disabled by Github: https://github.blog/2021-09-01-improving-git-protocol-security-github/