### PR TITLE
Replace all unecrypted git references in pip commands

### DIFF
--- a/container/makefiles/frontend.mk
+++ b/container/makefiles/frontend.mk
@@ -5,7 +5,7 @@ set-version: ## Set Home Assistant version
 	@bash /opt/container/helpers/common/homeassistant/set-version.sh
 
 install:  ## Install Home Assistant dev in the container
-	@python3 -m pip --disable-pip-version-check install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev
+	@python3 -m pip --disable-pip-version-check install --upgrade git+https://github.com/home-assistant/home-assistant.git@dev
 
 upgrade:  ## Upgrade Home Assistant to latest dev in the container
 	install

--- a/container/makefiles/generic.mk
+++ b/container/makefiles/generic.mk
@@ -5,7 +5,7 @@ set-version: ## Set Home Assistant version
 	@bash /opt/container/helpers/common/homeassistant/set-version.sh
 
 install:  ## Install Home Assistant dev in the container
-	@python3 -m pip --disable-pip-version-check install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev
+	@python3 -m pip --disable-pip-version-check install --upgrade git+https://github.com/home-assistant/home-assistant.git@dev
 
 upgrade:  ## Upgrade Home Assistant to latest dev in the container
 	install

--- a/container/makefiles/integration.mk
+++ b/container/makefiles/integration.mk
@@ -5,7 +5,7 @@ set-version: ## Set Home Assistant version
 	@bash /opt/container/helpers/common/homeassistant/set-version.sh
 
 install:  ## Install Home Assistant dev in the container
-	@python3 -m pip --disable-pip-version-check install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev
+	@python3 -m pip --disable-pip-version-check install --upgrade git+https://github.com/home-assistant/home-assistant.git@dev
 
 upgrade:  ## Upgrade Home Assistant to latest dev in the container
 	install

--- a/include/install/devcontainer/integration.sh
+++ b/include/install/devcontainer/integration.sh
@@ -15,6 +15,6 @@ apt-get install -y --no-install-recommends \
 mkdir -p /config/custom_components
 
 python3 -m pip --disable-pip-version-check install --upgrade \
-    git+git://github.com/home-assistant/home-assistant.git@dev
+    git+https://github.com/home-assistant/home-assistant.git@dev
 
 bash /include/cleanup/python.sh

--- a/rootfs/common/usr/share/container/upgrade
+++ b/rootfs/common/usr/share/container/upgrade
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 function UpdgradeHomeAssistantDev {
-  python3 -m pip install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev
+  python3 -m pip install --upgrade git+https://github.com/home-assistant/home-assistant.git@dev
 }


### PR DESCRIPTION
I guess there were a lot more of those references to the unencrypted git URL than I thought in https://github.com/ludeeus/container/pull/242. This should take care of all of the rest of them.