### PR TITLE
Update the integration container to install additional dependencies

### DIFF
--- a/include/install/devcontainer/integration.sh
+++ b/include/install/devcontainer/integration.sh
@@ -14,6 +14,7 @@ apt-get install -y --no-install-recommends \
     libavfilter-dev \
     libavformat-dev \
     libavutil-dev \
+    libpcap-dev \
     libswscale-dev \
     libswresample-dev \
     zlib1g-dev

--- a/include/install/devcontainer/integration.sh
+++ b/include/install/devcontainer/integration.sh
@@ -8,7 +8,6 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install -y --no-install-recommends \
-    ffmpeg \
     libjpeg-dev \
     libavcodec-dev \
     libavdevice-dev \

--- a/include/install/devcontainer/integration.sh
+++ b/include/install/devcontainer/integration.sh
@@ -8,7 +8,15 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
 apt-get install -y --no-install-recommends \
+    ffmpeg \
     libjpeg-dev \
+    libavcodec-dev \
+    libavdevice-dev \
+    libavfilter-dev \
+    libavformat-dev \
+    libavutil-dev \
+    libswscale-dev \
+    libswresample-dev \
     zlib1g-dev
 
 
@@ -16,5 +24,6 @@ mkdir -p /config/custom_components
 
 python3 -m pip --disable-pip-version-check install --upgrade \
     git+https://github.com/home-assistant/home-assistant.git@dev
+python3 -m pip --disable-pip-version-check install --upgrade wheel setuptools
 
 bash /include/cleanup/python.sh


### PR DESCRIPTION
* The stream component requires ffmpeg's libs
* The default_config requires PyTurboJPEG which depends on setuptools or wheel to install correctly
* libpcap-dev avoids this error: `ERROR (MainThread) [homeassistant.components.dhcp] Cannot watch for dhcp packets without a functional packet filter: libpcap is not available. Cannot compile filter !`
