### PR TITLE
Refactor docker images & github release update scripts

### DIFF
--- a/scripts/updates/alpine.py
+++ b/scripts/updates/alpine.py
@@ -1,52 +1,6 @@
 """Update alpine."""
-from typing import TYPE_CHECKING
-import requests
 
-from version import Version
-from jsonfile import JsonFile
+from common_image import update_image
 
-URL = "https://registry.hub.docker.com/v2/repositories/library/alpine/tags"
-skip = ["3.9", "3.9.6", "edge", "latest"]
 
-if TYPE_CHECKING:
-    from .version import Version
-    from .jsonfile import JsonFile
-
-alpine_base_config = JsonFile("./containerfiles/alpine/base/config.json")
-alpine_s6_base_config = JsonFile("./containerfiles/alpine-s6/base/config.json")
-alpine_node_config = JsonFile("./containerfiles/alpine/node/config.json")
-alpine_python_config = JsonFile("./containerfiles/alpine/python/config.json")
-
-current = Version(alpine_base_config.read()["args"]["BUILD_FROM_TAG"])
-
-request = requests.get(URL).json()
-tags = sorted(
-    [
-        x["name"]
-        for x in request["results"]
-        if x["name"][0].isdigit()
-        and x["name"] not in skip
-        and "." in x["name"]
-        and not Version(x["name"]).release_candidate
-    ]
-)
-
-upstream = Version(tags.pop())
-
-if current == upstream:
-    print(f"Nothing to do, both current and upstream is {current}")
-    exit(0)
-
-alpine_base_config.update("args.BUILD_FROM_TAG", upstream.string)
-alpine_base_config.update("tags", upstream.tags)
-
-alpine_node_config.update("args.BUILD_FROM_TAG", upstream.string)
-alpine_python_config.update("args.BUILD_FROM_TAG", upstream.string)
-alpine_s6_base_config.update("args.BUILD_FROM_TAG", upstream.string)
-alpine_s6_base_config.update("tags", upstream.tags)
-
-with open("./commit", "w") as commit:
-    commit.write(f"Update Alpine from {current.string} to {upstream.string}")
-
-with open("./labels", "w") as labels:
-    labels.write("alpine/base")
+update_image("alpine", lambda v: not v.release_candidate)

--- a/scripts/updates/common_image.py
+++ b/scripts/updates/common_image.py
@@ -1,0 +1,75 @@
+"""Update image."""
+from typing import Callable
+import requests
+
+from version import Version
+from jsonfile import JsonFile
+
+URL = (
+    "https://registry.hub.docker.com/v2/repositories/library/{image}/tags?page_size=100"
+)
+BASE_CONFIG_FILE = "./containerfiles/{image}/base/config.json"
+S6_BASE_CONFIG_FILE = "./containerfiles/{image}-s6/base/config.json"
+NODE_CONFIG_FILE = "./containerfiles/{image}/node/config.json"
+PYTHON_CONFIG_FILE = "./containerfiles/{image}/python/config.json"
+
+
+def _get_all_tags(
+    image: str,
+    should_use_tag: Callable[[Version], bool],
+    filter_tag_name: str | None = None,
+) -> list[Version]:
+    """Get all tags from api."""
+    tags = []
+    url = URL.format(image=image)
+    if filter_tag_name:
+        url += f"&name={filter_tag_name}"
+
+    while url:
+
+        request = requests.get(url).json()
+        for entry in request["results"]:
+            name = entry["name"]
+            if name[0].isdigit() and "." in name:
+                version = Version(name)
+                if should_use_tag(version):
+                    tags.append(version)
+
+        url = request.get("next", None)
+
+    return sorted(tags)
+
+
+def update_image(
+    image: str,
+    should_use_tag: Callable[[Version], bool],
+    filter_tag_name: str | None = None,
+) -> None:
+    """Update given image."""
+    base_config = JsonFile(BASE_CONFIG_FILE.format(image=image))
+    s6_base_config = JsonFile(S6_BASE_CONFIG_FILE.format(image=image))
+    node_config = JsonFile(NODE_CONFIG_FILE.format(image=image))
+    python_config = JsonFile(PYTHON_CONFIG_FILE.format(image=image))
+    current = Version(base_config.read()["args"]["BUILD_FROM_TAG"])
+
+    tags = _get_all_tags(image, should_use_tag, filter_tag_name)
+    upstream = tags.pop()
+
+    if current == upstream:
+        print(f"Nothing to do, both current and upstream is {current}")
+        exit(0)
+
+    base_config.update("args.BUILD_FROM_TAG", upstream.string)
+    base_config.update("tags", upstream.tags)
+    base_config_tag = upstream.tags[-1]
+
+    node_config.update("args.BUILD_FROM_TAG", base_config_tag)
+    python_config.update("args.BUILD_FROM_TAG", base_config_tag)
+    s6_base_config.update("args.BUILD_FROM_TAG", base_config_tag)
+    s6_base_config.update("tags", upstream.tags)
+
+    with open("./commit", "w", encoding="UTF-8") as commit:
+        commit.write(f"Update {image} from {current.string} to {upstream.string}")
+
+    with open("./labels", "w", encoding="UTF-8") as labels:
+        labels.write(f"{image}/base")

--- a/scripts/updates/debian.py
+++ b/scripts/updates/debian.py
@@ -1,51 +1,6 @@
 """Update debian."""
-from typing import TYPE_CHECKING
-import requests
 
-from version import Version
-from jsonfile import JsonFile
+from common_image import update_image
 
-URL = "https://registry.hub.docker.com/v1/repositories/library/debian/tags"
-skip = ["3.9", "3.9.6", "edge", "latest"]
 
-if TYPE_CHECKING:
-    from .version import Version
-    from .jsonfile import JsonFile
-
-debian_base_config = JsonFile("./containerfiles/debian/base/config.json")
-debian_s6_base_config = JsonFile("./containerfiles/debian-s6/base/config.json")
-debian_node_config = JsonFile("./containerfiles/debian/node/config.json")
-debian_python_config = JsonFile("./containerfiles/debian/python/config.json")
-
-current = Version(debian_base_config.read()["args"]["BUILD_FROM_TAG"].split("-")[0])
-
-request = requests.get(URL).json()
-tags = [
-    x["name"]
-    for x in request
-    if x["name"][0].isdigit()
-    and x["name"] not in skip
-    and "." in x["name"]
-    and "-slim" in x["name"]
-    and int(x["name"].split(".")[0]) >= 10
-]
-
-upstream = Version(tags.pop().split("-")[0])
-
-if current == upstream:
-    print(f"Nothing to do, both current and upstream is {current}")
-    exit(0)
-
-debian_base_config.update("args.BUILD_FROM_TAG", f"{upstream.string}-slim")
-debian_base_config.update("tags", upstream.tags)
-
-debian_node_config.update("args.BUILD_FROM_TAG", upstream.string)
-debian_python_config.update("args.BUILD_FROM_TAG", upstream.string)
-debian_s6_base_config.update("args.BUILD_FROM_TAG", upstream.string)
-debian_s6_base_config.update("tags", upstream.tags)
-
-with open("./commit", "w") as commit:
-    commit.write(f"Update Debian from {current.string} to {upstream.string}")
-
-with open("./labels", "w") as labels:
-    labels.write("debian/base")
+update_image("debian", lambda v: v.section(0) >= 10, "slim")

--- a/scripts/updates/ghcli.py
+++ b/scripts/updates/ghcli.py
@@ -1,29 +1,9 @@
 """Update ghcli."""
-from typing import TYPE_CHECKING
-import requests
+from github import update_with_github_release
 
-from version import Version
-from jsonfile import JsonFile
-from github import github_release
-
-if TYPE_CHECKING:
-    from .version import Version
-    from .jsonfile import JsonFile
-
-install_ghcli_version = JsonFile("./include/install/ghcli/versions.json")
-
-current = Version(install_ghcli_version.read()["ghcli"])
-upstream = Version(github_release("cli/cli"))
-
-if current == upstream:
-    print(f"Nothing to do, both current and upstream is {current}")
-    exit(0)
-
-
-install_ghcli_version.update("ghcli", upstream.string)
-
-with open("./commit", "w") as commit:
-    commit.write(f"Update GitHub CLI from {current.string} to {upstream.string}")
-
-with open("./labels", "w") as labels:
-    labels.write("devcontainer")
+update_with_github_release(
+    "GitHub CLI",
+    "ghcli",
+    "cli/cli",
+    "devcontainer",
+)

--- a/scripts/updates/github.py
+++ b/scripts/updates/github.py
@@ -1,8 +1,12 @@
 """Parse github release for version."""
 import requests
+from version import Version
+from jsonfile import JsonFile
+
+VERSION_FILE = "./include/install/{folder}/versions.json"
 
 
-def github_release(repo):
+def _github_release(repo):
     url = f"https://github.com/{repo}/releases/latest"
     response = requests.get(url).text
     return (
@@ -11,3 +15,31 @@ def github_release(repo):
         .split(">")[-1]
         .replace("v", "")
     )
+
+
+def update_with_github_release(
+    name: str,
+    file_section: str,
+    repository: str,
+    labels: str,
+    include_install_folder: str | None = None,
+):
+    """Update version with a github release."""
+    if not include_install_folder:
+        include_install_folder = file_section
+
+    version_file = JsonFile(VERSION_FILE.format(folder=include_install_folder))
+    current = Version(version_file.read()[file_section])
+    upstream = Version(_github_release(repository))
+
+    if current == upstream:
+        print(f"Nothing to do, both current and upstream is {current}")
+        exit(0)
+
+    version_file.update(file_section, upstream.string)
+
+    with open("./commit", "w", encoding="UTF-8") as commit:
+        commit.write(f"Update {name} from {current.string} to {upstream.string}")
+
+    with open("./labels", "w", encoding="UTF-8") as labels_file:
+        labels_file.write(labels)

--- a/scripts/updates/s6.py
+++ b/scripts/updates/s6.py
@@ -1,29 +1,4 @@
 """Update s6."""
-from typing import TYPE_CHECKING
-import requests
+from github import update_with_github_release
 
-from version import Version
-from jsonfile import JsonFile
-from github import github_release
-
-if TYPE_CHECKING:
-    from .version import Version
-    from .jsonfile import JsonFile
-
-install_s6_version = JsonFile("./include/install/s6/versions.json")
-
-current = Version(install_s6_version.read()["s6"])
-upstream = Version(github_release("just-containers/s6-overlay"))
-
-if current == upstream:
-    print(f"Nothing to do, both current and upstream is {current}")
-    exit(0)
-
-
-install_s6_version.update("s6", upstream.string)
-
-with open("./commit", "w") as commit:
-    commit.write(f"Update S6 from {current.string} to {upstream.string}")
-
-with open("./labels", "w") as labels:
-    labels.write("S6")
+update_with_github_release("S6", "s6", "just-containers/s6-overlay", "S6")

--- a/scripts/updates/version.py
+++ b/scripts/updates/version.py
@@ -1,9 +1,30 @@
-from awesomeversion import AwesomeVersion
+"""Version module."""
+
+from awesomeversion import (
+    AwesomeVersion,
+    AwesomeVersionCompareException,
+    AwesomeVersionStrategy,
+)
+from awesomeversion.typing import VersionType
+
+
+def _get_first_match_version(version: VersionType) -> AwesomeVersion:
+    return AwesomeVersion(
+        version,
+        ensure_strategy=[
+            AwesomeVersionStrategy.SEMVER,
+            AwesomeVersionStrategy.SIMPLEVER,
+        ],
+        find_first_match=True,
+    )
 
 
 class Version(AwesomeVersion):
+    """Version object."""
+
     @property
     def tags(self):
+        """Get all tags."""
         tags = ["latest"]
         tags.append(str(self.section(0)))
         if self.sections > 1:
@@ -11,3 +32,16 @@ class Version(AwesomeVersion):
         if self.sections > 2:
             tags.append(f"{self.section(0)}.{self.section(1)}.{self.section(2)}")
         return tags
+
+    def __lt__(self, compareto: VersionType) -> bool:
+        """Check if less than."""
+        try:
+            return super().__lt__(compareto)
+        except AwesomeVersionCompareException:
+            # "11.5-slim" has the AwesomeVersionStrategy.UNKNOWN and with that strategy __lt__ is not working
+            # Using this as workaround by ignoring modifier
+            return _get_first_match_version(self) < _get_first_match_version(compareto)
+
+    def __gt__(self, compareto: VersionType) -> bool:
+        """Check if greater than."""
+        return not self.__le__(compareto)

--- a/scripts/updates/yarn.py
+++ b/scripts/updates/yarn.py
@@ -1,29 +1,10 @@
 """Update yarn."""
-from typing import TYPE_CHECKING
-import requests
+from github import update_with_github_release
 
-from version import Version
-from jsonfile import JsonFile
-from github import github_release
-
-if TYPE_CHECKING:
-    from .version import Version
-    from .jsonfile import JsonFile
-
-install_yarn_version = JsonFile("./include/install/node/versions.json")
-
-current = Version(install_yarn_version.read()["yarn"])
-upstream = Version(github_release("yarnpkg/yarn"))
-
-if current == upstream:
-    print(f"Nothing to do, both current and upstream is {current}")
-    exit(0)
-
-
-install_yarn_version.update("yarn", upstream.string)
-
-with open("./commit", "w") as commit:
-    commit.write(f"Update Yarn from {current.string} to {upstream.string}")
-
-with open("./labels", "w") as labels:
-    labels.write("node,debian/node,alpine/node")
+update_with_github_release(
+    "Yarn",
+    "yarn",
+    "yarnpkg/yarn",
+    "node,debian/node,alpine/node",
+    "node",
+)


### PR DESCRIPTION
During `make update-all` I noticed , that `update-debian`is not working anymore as it still uses docker hub v1 api.
During the fixing of `debian.py`, I noticed that there is a lot of common code with `alpine.sh`.

Therefore I have refactored both. Sorting the tags in a string manner was not working correctly and so I used the Version class.
As "11.5-slim" was not a valid Version, I modified the `__gt__` and `__lt__`in the `version.py`. Not sure it this is the best approach/workaround but what do you think?

I also refactored the update scripts, which uses github_release as upstream version. I have committed it in two commits, but I can split it in two PR if you want.
Please let me know :)